### PR TITLE
Added a configuration object and a random generator

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,30 @@
+{
+  "autoPin": true,
+  "pins": [
+    {
+      "package": "Bits",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/bits.git",
+      "version": "1.0.0-beta1"
+    },
+    {
+      "package": "Core",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/core.git",
+      "version": "2.0.0-beta1"
+    },
+    {
+      "package": "Debugging",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/debugging.git",
+      "version": "1.0.0-beta1"
+    },
+    {
+      "package": "Random",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/random.git",
+      "version": "1.0.0-beta.1"
+    }
+  ],
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,13 @@ import PackageDescription
 let package = Package(
   name: "OSSMCore",
   targets: [
+    Target(name: "Configuration", dependencies: ["Geography", "Localization", "Population"]),
     Target(name: "Calendar"),
     Target(name: "Localization"),
     Target(name: "Geography", dependencies: ["Localization"]),
     Target(name: "Population", dependencies: ["Geography"]),
+  ],
+  dependencies: [
+    .Package(url: "https://github.com/vapor/random.git", Version(1,0,0, prereleaseIdentifiers: ["beta"])),
   ]
 )

--- a/Sources/Calendar/Timeline.swift
+++ b/Sources/Calendar/Timeline.swift
@@ -3,24 +3,19 @@ import Foundation
 /*
   A timeline of the game simulation.
 
-  It uses a singleton instance of itself.
-
   Keeps track of the game timeline in memory and should persist to database on every tick.
 */
 public final class Timeline {
 
-  static let sharedInstance = Timeline()
-
-  // private init so Timeline is only used as a singleton instance
-  private init() {
+  public init() {
     gameDate = Date(year: 0, day: 0, hour: 0, minute: 0, second: 0)
-    timer = Timer(timeInterval: 1, repeats: true) { timer in
-       Timeline.sharedInstance.timerTick()
+    timer = Timer(timeInterval: 1, repeats: true) { [weak self] timer in
+       self?.timerTick()
     }
   }
 
   private var gameDate: Date
-  private var timer: Timer
+  private var timer: Timer?
 
   /// tick the timer every second to add a second to the game time
   func timerTick() {

--- a/Sources/Configuration/ConfigurationError.swift
+++ b/Sources/Configuration/ConfigurationError.swift
@@ -1,0 +1,4 @@
+public enum ConfigurationError: Error {
+  /// You are trying to use OSSM functions without an OSSM instance.
+  case noConfigurationInstance
+}

--- a/Sources/Configuration/OSSM.swift
+++ b/Sources/Configuration/OSSM.swift
@@ -1,0 +1,40 @@
+import Calendar
+import Geography
+import Population
+import Random
+
+/*
+  Service container for an OSSM instance. Brings together all related classes.
+
+  Set your configurations on this class.
+*/
+public final class OSSM {
+
+  /// The name of this instance.
+  public let name: String
+
+  /// The instance's timeline.
+  public let timeline = Timeline()
+
+  /// The root location of this instance's geography.
+  public let rootLocation: Location
+
+  /// The name generator.
+  public let nameGenerator: NameGenerator
+
+  /// The random number generator to use.
+  public let random: RandomProtocol
+
+  public init(
+    name: String,
+    rootLocation: Location,
+    nameGenerator: NameGenerator,
+    random: RandomProtocol?
+  ) throws {
+    self.name = name
+    self.rootLocation = rootLocation
+    self.nameGenerator = nameGenerator
+    self.random = try random ?? URandom()
+  }
+
+}

--- a/Sources/Population/Names/NameGenerator.swift
+++ b/Sources/Population/Names/NameGenerator.swift
@@ -1,4 +1,5 @@
 import Geography
+import Random
 
 /**
   Generates names for Sims.
@@ -15,14 +16,17 @@ public class NameGenerator {
 
   let namesTable: [Location: NamesList]
 
-  public init(namesTable: [Location: NamesList]) {
+  let randomGenerator: RandomProtocol
+
+  public init(namesTable: [Location: NamesList], randomGenerator: RandomProtocol) {
     self.namesTable = namesTable
+    self.randomGenerator = randomGenerator
   }
 
   public func generate(for location: Location) throws -> Name {
     // Choose a random name from the concatenated NamesLists of this location
     // and all parent locations.
-    return try namesList(for: location).random()
+    return try namesList(for: location).random(using: randomGenerator)
   }
 
   func namesList(for location: Location) -> NamesList {

--- a/Sources/Population/Names/NamesList+Random.swift
+++ b/Sources/Population/Names/NamesList+Random.swift
@@ -1,0 +1,15 @@
+import Random
+
+extension NamesList {
+
+  func random(using randomGenerator: RandomProtocol) throws -> Name {
+    guard firstNames.count > 0, lastNames.count > 0 else {
+      throw NameError.emptyNameList
+    }
+    return try Name(
+      first: firstNames[abs(randomGenerator.makeInt() % firstNames.count)],
+      last: lastNames[abs(randomGenerator.makeInt() % lastNames.count)]
+    )
+  }
+
+}

--- a/Sources/Population/Names/NamesList.swift
+++ b/Sources/Population/Names/NamesList.swift
@@ -16,17 +16,6 @@ public struct NamesList {
     self.lastNames = lastNames
   }
 
-  func random() throws -> Name {
-    // TODO: This should use whatever random number generator we choose.
-    guard
-      let firstName = firstNames.first,
-      let lastName = lastNames.first
-    else {
-      throw NameError.emptyNameList
-    }
-    return Name(first: firstName, last: lastName)
-  }
-
 }
 
 

--- a/Tests/ConfigurationTests/ConfigurationTests.swift
+++ b/Tests/ConfigurationTests/ConfigurationTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import Configuration
+
+class ConfigurationTests: XCTestCase {
+
+  static var allTests: [(String, (ConfigurationTests) -> () -> ())] = []
+
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,11 +1,13 @@
 import XCTest
 @testable import CalendarTests
+@testable import ConfigurationTests
 @testable import GeographyTests
 @testable import LocalizationTests
 @testable import PopulationTests
 
 XCTMain([
   testCase(CalendarTests.allTests),
+  testCase(ConfigurationTests.allTests),
   testCase(GeographyTests.allTests),
   testCase(LocalizationTests.allTests),
   // Population

--- a/Tests/PopulationTests/NamesTests.swift
+++ b/Tests/PopulationTests/NamesTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Geography
+import Random
 @testable import Population
 
 class NamesTests: XCTestCase {
@@ -18,7 +19,7 @@ class NamesTests: XCTestCase {
     XCTAssertEqual(combined.lastNames, ["ONE", "TWO"])
   }
 
-  func testParentLocationNamesLists() {
+  func testParentLocationNamesLists() throws {
     // Create the geography
     let root = Location(name: "ROOT", parent: nil)
     let leaf = Location(name: "LEAF", parent: root)
@@ -26,7 +27,7 @@ class NamesTests: XCTestCase {
     let generator = NameGenerator(namesTable: [
       root: NamesList(firstNames: ["one"], lastNames: ["ONE"]),
       leaf: NamesList(firstNames: ["two"], lastNames: ["TWO"])
-    ])
+    ], randomGenerator: try URandom())
     // Get the concatenated list
     let combined = generator.namesList(for: leaf)
     XCTAssertEqual(combined.firstNames, ["two", "one"])
@@ -42,9 +43,10 @@ class NamesTests: XCTestCase {
         firstNames: ["fred", "bob", "bill"],
         lastNames: ["smith"]
       ),
-    ])
+    ], randomGenerator: try URandom())
     // Generate a name
     let name = try generator.generate(for: root)
+    print("Name: \(name)")
     XCTAssertTrue(["fred", "bob", "bill"].contains(name.first))
     XCTAssertEqual("smith", name.last)
   }


### PR DESCRIPTION
Couple things here.

1) Vapor uses a `Droplet` which it calls a service configuration object. It's basically a class which you create an instance of, then set configurations on, which can get passed around, and avoids the need for singletons. I have introduced something like that for OSSM, it holds a reference to the geography, the timeline, the random number generator. So an end-user (including us) would launch an OSSM server something like this:

```Swift
import Configuration

let instance = OSSM(... config ...)
instance.api.run()
```

I'm not sure about the API for this, but we can see how we go.

2) I added a random number generator, or at least I took the ones from Vapor.